### PR TITLE
ci: add bootBuildImage script for fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -187,3 +187,20 @@ jooq {
         }
     }
 }
+
+bootBuildImage {
+  def containerRegistry = System.getenv("CONTAINER_REGISTRY") ?: "ghcr.io"
+  def containerImageName = System.getenv("CONTAINER_IMAGE_NAME") ?: "sweatboys/${rootProject.name}"
+  def containerImageVersion = System.getenv("CONTAINER_IMAGE_VERSION") ?: "latest"
+
+  imageName = "${containerRegistry}/${containerImageName}:${containerImageVersion}"
+  builder = "paketobuildpacks/builder:tiny"
+  publish = false
+  docker {
+    publishRegistry {
+      username = System.getenv("CONTAINER_REGISTRY_USER") ?: ""
+      password = System.getenv("CONTAINER_REGISTRY_PASSWORD") ?: ""
+      url = "https://${containerRegistry}"
+    }
+  }
+}


### PR DESCRIPTION
Currently not working due to malformed image tags. This will fix registry, image, version to be merged.