### PR TITLE
ci: removes logic for ci-labels-release-gen

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
     env:
       CONTAINER_IMAGE_VERSION: ${{ needs.release.outputs.tag_name }}
     runs-on: ubuntu-latest
-    if: ${{ github.ref == 'refs/heads/main' && needs.release.outputs.release_created }}
+    if: ${{ github.ref == 'refs/heads/main' }}
     needs:
       - build
       - release


### PR DESCRIPTION
TLDR: opens main branch to publish on call.