### PR TITLE
ci: updates dockerfile to use JDK 17 temurin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,11 @@ ARG OTEL_AGENT_VERSION="1.21.0"
 RUN curl --silent --fail -L "https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v${OTEL_AGENT_VERSION}/opentelemetry-javaagent.jar" \
     -o "$HOME/opentelemetry-javaagent.jar"
 
-FROM gradle:jdk19-alpine AS build
+FROM eclipse-temurin:17-alpine AS build
 ADD . /
-RUN cd / && gradle bootJar --quiet
+RUN cd / && ./gradlew bootJar --quiet
 
-FROM eclipse-temurin:19-alpine
+FROM eclipse-temurin:17-alpine
 COPY --from=build /build/libs/*.jar /app.jar
 COPY --from=download /home/curl_user/opentelemetry-javaagent.jar /opentelemetry-javaagent.jar
 


### PR DESCRIPTION
It seems GitHub Action currently does not support temurin JDK 19. Downgrading to JDK17 is even better.

Closes #28.