### PR TITLE
feat: routes actuator to API_SERVER_HOST target

### DIFF
--- a/src/main/java/io/dsub/sweatboys/opendiscogs/api/Application.java
+++ b/src/main/java/io/dsub/sweatboys/opendiscogs/api/Application.java
@@ -7,7 +7,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
 // {x-release-please-start-version}
-@OpenAPIDefinition(info = @Info(title = "Open Discogs API", version = "1.1.0", description = "Documentation APIs v0.0.0"))
+@OpenAPIDefinition(info = @Info(title = "Open Discogs API", version = "1.1.0", description = "Documentation APIs 1.1.0"))
 // {x-release-please-end}
 public class Application {
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -44,10 +44,17 @@ springdoc:
     path: /swagger-doc/v3/api-docs
     groups:
       enabled: true
+    resolve-schema-properties: true
   swagger-ui:
     enabled: true
-    path: /docs
+    disable-swagger-default-url: true
+    urls:
+      - name: Open Discogs API
+        url: ${API_SERVER_HOST}
   show-spring-cloud-functions: false
-  show-actuator: false
+  show-actuator: true
   use-management-port: true
   enable-native-support: true
+  model-converters:
+    polymorphic-converter:
+      enabled: true


### PR DESCRIPTION
adds little option for routing swagger-doc to resolve with ${API_SERVER_HOST} env.