### PR TITLE
merge PR for dev/helm lint

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,8 +12,6 @@
 name: "CodeQL"
 
 on:
-  push:
-    branches: [ "main" ]
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ "main" ]
@@ -41,7 +39,7 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3
-      
+
     - name: ☕ Set up GraalVM JDK 17
       uses: graalvm/setup-graalvm@v1
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,12 +18,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set up JDK
-        uses: actions/setup-java@v3
+      - name: ☕ Set up GraalVM JDK 17
+        uses: graalvm/setup-graalvm@v1
         with:
-          java-version: "17.0"
-          distribution: 'temurin'
-          cache: gradle
+          version: 'latest'
+          java-version: '17'
+          components: 'native-image'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          cache: 'gradle'
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Build with Gradle

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -55,9 +55,14 @@ spec:
             periodSeconds: 5
             failureThreshold: 30
           env:
-            {{- range $key, $value := .Values.application.env }}
-            - name: {{ $key }}
-              value: {{ $value | quote }}
+            {{- range $k, $v := .Values.application.env }}
+            {{- if kindIs "string" $v }}
+            - name: {{ $k }}
+              value: {{ $v }}
+            {{- else }}
+            - name: {{ $v.name }}
+              value: {{ $v.value }}
+            {{- end }}
             {{- end }}
             - name: SPRING_APPLICATION_NAME
               value: {{ .Values.application.name }}


### PR DESCRIPTION
1. enables faster main branch build (basically skipping CodeQL, since we already do that on PR against main)
2. release job > build now runs on GraalVM to prepare future build on natives.
3. fixes again (sorry) for the helm deployment chart parser