### PR TITLE
build: keep Dependabot on Java 21

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,10 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    ignore:
+      - dependency-name: eclipse-temurin
+        update-types:
+          - version-update:semver-major
     commit-message:
       prefix: build
       include: scope


### PR DESCRIPTION
## Summary

- keep automated Temurin updates on the coordinated Java 21 LTS line
- prevent isolated Java major upgrades in the API container
- continue receiving non-major Docker dependency updates

## Verification

- parsed `.github/dependabot.yml` and asserted the exact Docker ignore rule
- Actionlint
- `git diff --check`

This follows the failed Java 25 container-only update in #74. Java major upgrades must be coordinated across open-discogs-jooq, open-discogs-batch, and open-discogs-api.