### PR TITLE
fix: prevent documentation-only releases

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,52 +5,6 @@
   "include-component-in-tag": false,
   "include-v-in-tag": true,
   "pull-request-title-pattern": "build: release ${version}",
-  "changelog-sections": [
-    {
-      "type": "build",
-      "section": "Build System"
-    },
-    {
-      "type": "chore",
-      "section": "Maintenance"
-    },
-    {
-      "type": "ci",
-      "section": "Continuous Integration"
-    },
-    {
-      "type": "docs",
-      "section": "Documentation"
-    },
-    {
-      "type": "feat",
-      "section": "Features"
-    },
-    {
-      "type": "fix",
-      "section": "Bug Fixes"
-    },
-    {
-      "type": "perf",
-      "section": "Performance Improvements"
-    },
-    {
-      "type": "refactor",
-      "section": "Code Refactoring"
-    },
-    {
-      "type": "revert",
-      "section": "Reverts"
-    },
-    {
-      "type": "style",
-      "section": "Styles"
-    },
-    {
-      "type": "test",
-      "section": "Tests"
-    }
-  ],
   "packages": {
     ".": {
       "package-name": "open-discogs-api",


### PR DESCRIPTION
## Summary

- restore Release Please's default changelog section semantics
- prevent `docs:` commits from creating patch releases
- preserve patch releases for `fix:`, minor releases for `feat:`, and major releases for breaking changes
- keep GHCR publication gated on `release_created == true`

## Verification

- simulated the pinned Release Please 17.6.0 behavior from 1.6.1:
  - `docs:` → no release PR
  - `fix:` → 1.6.2
  - `feat:` → 1.7.0
  - breaking change → 2.0.0
- `actionlint .github/workflows/*.yml`
- `./gradlew clean check --no-daemon --warning-mode=fail`
- `git diff --check`
